### PR TITLE
Allow multi arguments on logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const os = require( 'os' );
 const util = require( 'util' );
+const stackTrace = require('stack-trace');
 
 const constantFields = {
   system: process.env.SYSTEM_NAME || 'Not defined',
@@ -17,11 +18,9 @@ const methods = {
 
 function getCallerFile() {
   const err = new Error();
-
-  Error.prepareStackTrace = ( error, stack ) => stack;
-
-  const currentFile = err.stack.shift().getFileName();
-  const caller = err.stack.find( line => line.getFileName() !== currentFile );
+  const stack = stackTrace.parse(err)
+  const currentFile = stack.shift().getFileName();
+  const caller = stack.find( line => line.getFileName() !== currentFile );
 
   return caller.getFileName();
 }
@@ -32,7 +31,11 @@ function wasCalledFromModule() {
 }
 
 function buildFields( props, metaFields ) {
-  const fields = Object.assign( {}, props, constantFields, metaFields );
+  const updatedProps = Object.assign({}, props);
+  if(props.message instanceof Array) {
+    updatedProps.message = props.message.join(' ');
+  }
+  const fields = Object.assign( {}, updatedProps, constantFields, metaFields );
   fields.timestamp = new Date().toISOString();
   return fields;
 }
@@ -50,8 +53,9 @@ Object.keys( methods ).forEach( key => {
         return target( ...args );
       }
 
-      const props = ( args[0] && args[0].constructor.name === 'Object' ) ? args[0] : { message: args[0] };
+      const props = ( args[0] && args[0].constructor.name === 'Object' ) ? args[0] : { message: args };
       const fields = buildFields( props, methods[key] );
+
       process.stdout.write( `${util.format( JSON.stringify( fields ) )}\n` );
     }
   } );

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.3.2",
   "description": "A lib to change default default of the console object, in order to do extended logs.",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "stack-trace": "0.0.10"
+  },
   "devDependencies": {
     "chai": "3.5.0",
     "chai-http": "^3.0.0",

--- a/spec/meta_spec.js
+++ b/spec/meta_spec.js
@@ -100,6 +100,18 @@ describe( 'Meta spec', () => {
       expect( args.type ).to.eql( 'log' );
     } );
 
+    it( 'Should accept more than one string argument', () => {
+      console.info('test', 'test2');
+      const args = JSON.parse( writeSpy.lastCall.args[0] );
+      expect( args.message ).to.eql( 'test test2' );
+    } );
+
+    it( 'Should accept more than one argument', () => {
+      console.info('test', JSON.stringify({name: 'Jon Doe'}));
+      const args = JSON.parse( writeSpy.lastCall.args[0] );
+      expect( args.message ).to.eql( 'test {"name":"Jon Doe"}' );
+    } );
+
     it( 'Should be "log" fro .error', () => {
       console.error();
       const args = JSON.parse( writeSpy.lastCall.args[0] );


### PR DESCRIPTION
when using `console.info` we should be able to log things like `console.info('message1', 'message2')`